### PR TITLE
Tidy up build and pipeline item labels

### DIFF
--- a/src/models/Build.ts
+++ b/src/models/Build.ts
@@ -73,10 +73,11 @@ export default class Build implements Node {
 
   getTreeItem() {
     return {
-      label: this.label(),
+      label: this.build.branch,
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       iconPath: this.iconPath(),
       tooltip: this.tooltip(),
+      description: this.description(),
       contextValue: this.context
     };
   }
@@ -134,9 +135,8 @@ export default class Build implements Node {
     }`;
   }
 
-  label() {
-    const relativeTime = moment.utc(this.build.startedAt).fromNow();
-    return `${this.build.branch} (${relativeTime})`;
+  description() {
+    return moment.utc(this.build.startedAt).fromNow();
   }
 
   iconPath() {

--- a/src/models/Pipeline.ts
+++ b/src/models/Pipeline.ts
@@ -35,15 +35,18 @@ export default class Pipeline implements Node {
       collapsibleState: this.builds.length
         ? vscode.TreeItemCollapsibleState.Collapsed
         : vscode.TreeItemCollapsibleState.None,
-      iconPath: this.iconPath
+      iconPath: this.iconPath,
+      description: this.description()
     };
   }
 
   private label() {
-    if (this.mostRecentBuildDateTime) {
-      const relativeTime = moment.utc(this.mostRecentBuildDateTime).fromNow();
-      return `${this.pipeline.name} (${relativeTime})`;
-    }
     return this.pipeline.name;
+  }
+
+  private description() {
+    if (this.mostRecentBuildDateTime) {
+      return moment.utc(this.mostRecentBuildDateTime).fromNow();
+    }
   }
 }


### PR DESCRIPTION
It's subtle but this change removes the parenthesis from the build labels making them slightly more readable. 

Before:
![Screenshot 2019-11-11 10 38 01](https://user-images.githubusercontent.com/656826/68552919-b0f64800-0470-11ea-8093-75708bff8896.png)

After:
![Screenshot 2019-11-11 10 44 47](https://user-images.githubusercontent.com/656826/68552921-b3f13880-0470-11ea-9344-e5acdda02fe2.png)
