### PR TITLE
Command categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "commands": [
       {
         "command": "buildkite-builds.refresh",
+        "category": "Buildkite",
         "title": "Refresh",
         "icon": {
           "light": "resources/light/refresh.svg",
@@ -53,6 +54,7 @@
       },
       {
         "command": "buildkite-pipelines.refresh",
+        "category": "Buildkite",
         "title": "Refresh",
         "icon": {
           "light": "resources/light/refresh.svg",
@@ -61,6 +63,7 @@
       },
       {
         "command": "buildkite.viewBuild",
+        "category": "Buildkite",
         "title": "View Build",
         "icon": {
           "light": "resources/light/external-link.svg",
@@ -69,18 +72,22 @@
       },
       {
         "command": "buildkite.viewPipeline",
+        "category": "Buildkite",
         "title": "View Pipeline"
       },
       {
         "command": "buildkite.viewPipelineBuilds",
+        "category": "Buildkite",
         "title": "View Pipeline Builds"
       },
       {
         "command": "buildkite.viewCommit",
+        "category": "Buildkite",
         "title": "View Commit"
       },
       {
         "command": "buildkite.viewPullRequest",
+        "category": "Buildkite",
         "title": "View Pull Request"
       }
     ],


### PR DESCRIPTION
Adds categories to commands to make it more easy to determine what some of the contributed commands are related to. For example, before the 'View Pull Request' command was unclear that it was contributed by the Buildkite extension.

## Before

<img width="188" alt="Screen Shot 2021-08-24 at 10 42 39 AM" src="https://user-images.githubusercontent.com/25914066/130647843-e66ef86f-1ca1-40a4-aab5-a4313f52f101.png">

## After (all commands)

<img width="417" alt="Screen Shot 2021-08-24 at 10 43 15 AM" src="https://user-images.githubusercontent.com/25914066/130647847-30754f42-30ef-472e-ac97-90518fad0bb6.png">
