### PR TITLE
Fix running commands from the command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Fixed error when attempting to set/delete token when extension hasn't been activated.
+- Fixed error when attempting to set/delete token when extension hasn't been activated
+
+### Removed
+- Removed UI commands from the command palette
 
 ## [1.0.0] - 2021-09-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Fixed error when attempting to set/delete token when extension hasn't been activated.
+
 ## [1.0.0] - 2021-09-28
 ### Added
 - Add new `buildkite.setToken` and `buildkite.deleteToken` commands to set the Buildkite access token as a secret. (@mskeleton)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   ],
   "activationEvents": [
     "onView:buildkite-builds",
-    "onView:buildkite-pipelines"
+    "onView:buildkite-pipelines",
+    "onCommand:buildkite.setToken",
+    "onCommand:buildkite.deleteToken"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,36 @@
       }
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "buildkite.viewBuild",
+          "when": "false"
+        },
+        {
+          "command": "buildkite.viewPipeline",
+          "when": "false"
+        },
+        {
+          "command": "buildkite.viewPipelineBuilds",
+          "when": "false"
+        },
+        {
+          "command": "buildkite.viewCommit",
+          "when": "false"
+        },
+        {
+          "command": "buildkite.viewPullRequest",
+          "when": "false"
+        },
+        {
+          "command": "buildkite-builds.refresh",
+          "when": "false"
+        },
+        {
+          "command": "buildkite-pipelines.refresh",
+          "when": "false"
+        }
+      ],
       "view/title": [
         {
           "command": "buildkite-builds.refresh",


### PR DESCRIPTION
This fixes a couple of issues when running commands directly from the command palette. The majority of commands can only be run in the context of the buildkite UI so they've now been excluded from showing up in the palette. 

For the token commands I'm now "activating" the extension which means first time users shouldn't see an error message when they run those commands outside of the buildkite view. I'm guessing this may have been the reason for an issue reported here https://github.com/dannymidnight/vscode-buildkite/issues/20#issuecomment-949673774.
