### PR TITLE
Fix invalid date for scheduled builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Fix bug in date formatting for scheduled builds
+
 ## [1.2.0] - 2023-08-02
 ### Changed
 - Fix query complexity issue [[#36](https://github.com/dannymidnight/vscode-buildkite/issues/36)]. Rather than performing one big query, queries are now performed on expansion of tree items.

--- a/src/models/Build.ts
+++ b/src/models/Build.ts
@@ -147,8 +147,12 @@ export default class Build implements Node {
   }
 
   description() {
-    const relativeTime = moment.utc(this.build.startedAt).fromNow();
-    return `${relativeTime} in ${this.build.pipeline.name}`;
+    if (this.build.startedAt) {
+      const relativeTime = moment.utc(this.build.startedAt).fromNow();
+      return `${relativeTime} in ${this.build.pipeline.name}`;
+    } else {
+      return `in ${this.build.pipeline.name}`;
+    }
   }
 
   iconPath() {


### PR DESCRIPTION
Scheduled builds don't have a `startedAt` timestamp which result in an `undefined` label.