### PR TITLE
[WIP] Add editable pipeline visualiser

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
     },
     "commands": [
       {
+        "command": "buildkite.previewPipeline",
+        "category": "Buildkite",
+        "title": "Preview Pipeline"
+      },
+      {
         "command": "buildkite-builds.refresh",
         "category": "Buildkite",
         "title": "Refresh",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,80 @@ const BUILDKITE_ACCESS_TOKEN = "buildkite.accessToken";
 export async function activate(context: vscode.ExtensionContext) {
   const client = await createGraphQLClient(context);
 
+  context.subscriptions.push(
+    vscode.commands.registerCommand("buildkite.previewPipeline", () => {
+      // const yaml = `
+      //   steps:
+      //     - label: ":rocket: Build"
+      //       command: "make build"
+      //     - label: ":package: Package"
+      //       command: "make package"
+      //     - label: ":ship: Deploy"
+      //       command: "make deploy"
+      // `;
+
+      const editor = vscode.window.activeTextEditor;
+
+      let yaml = editor?.document.getText();
+
+      const panel = vscode.window.createWebviewPanel(
+        "previewPipeline",
+        `Preview pipeline: ${editor?.document.fileName}`, // todo: maybe make this reference the file being opened.
+        vscode.ViewColumn.Beside,
+        {
+          enableScripts: true,
+          retainContextWhenHidden: true,
+        }
+      );
+
+      // todo: work out what kind of validation we want to do here.
+      vscode.workspace.onDidSaveTextDocument((e) => {
+        yaml = e.getText();
+        panel.webview.postMessage({ yaml });
+      });
+
+      // on change...
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        yaml = e.document.getText();
+        panel.webview.postMessage({ yaml });
+      });
+
+      panel.webview.html = `
+        <html>
+          <body>
+            <style>
+              body {
+                margin: 0;
+                padding: 0;
+                height: 100vh;
+                width: 100vw;
+                overflow: hidden;
+              }
+              iframe { border: 0; }
+            </style>
+
+            <script>
+              // Send YAML to the iframe when it's ready
+              window.addEventListener('message', event => {
+                const iframe = document.querySelector("iframe");
+
+                if (event.data.yaml) {
+                  console.log(event.data.yaml);
+
+                  iframe.contentWindow.postMessage({ yaml: event.data.yaml }, "*");
+                } else {
+                  iframe.contentWindow.postMessage({ yaml: \`${yaml}\` }, "*");
+                }
+              });
+            </script>
+
+            <iframe src="http://buildkite.localhost/pipelines/playground/embed" style="width: 100vw; height: 100vh;"></iframe>
+          </body>
+        </html>
+      `;
+    })
+  );
+
   // Register view data provider
   const pipelinesProvider = new PipelinesProvider(client);
   vscode.window.registerTreeDataProvider(


### PR DESCRIPTION
This drops in an experimental pipeline visualiser using the Buildkite playground.

It currently works something like the following...

```mermaid
sequenceDiagram
    workspace (vscode)->>workspace (vscode): onChange
    workspace (vscode)->>webview (vscode): postMessage
    webview (vscode)->>iframe (buildkite): postMessage

```

**What's missing?**
- Theming
- Highlighting errors

**What's broken?**
- Most of it!
- It's not currently scoped to the active pipeline.yaml file. 
- It picks up edits to any file and forwards them to the iframe.